### PR TITLE
fix: gallery mason grid overlapping

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,6 +31,6 @@
 {{- block "main" . }}{{- end }}
 
 {{- partial "footer.html" . -}}
-{{- partial "scripts.html" . -}}
+{{- block "scripts" . }}{{- end }}
 </body>
 </html>

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -11,7 +11,7 @@
     <section class="p-4 mb-5 module shadow-lg">
         {{ .Content }}
 
-        <div class="row" data-masonry='{"percentPosition": true }'>
+        <div id="masonry" class="row">
             {{ range (.Paginator 12).Pages }}
             {{ .Render "li" }}
             {{ end }}
@@ -22,4 +22,23 @@
         </div>
     </section>
 </main>
+{{ end }}
+
+{{ define "scripts" }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.1.4/imagesloaded.pkgd.min.js"
+    integrity="sha512-S5PZ9GxJZO16tT9r3WJp/Safn31eu8uWrzglMahDT4dsmgqWonRY9grk3j+3tfuPr9WJNsfooOR7Gi7HL5W2jw=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/masonry/4.2.2/masonry.pkgd.min.js"
+    integrity="sha512-JRlcvSZAXT8+5SQQAvklXGJuxXTouyq8oIMaYERZQasB8SBDHZaUbeASsJWpk0UUrf89DP3/aefPPrlMR1h1yQ=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        let grid = new Masonry(document.getElementById("masonry"), {});
+        imagesLoaded("#masonry", () => {
+            // trigger a layout refresh after images have loaded
+            // - necessary, otherwise images may overlap vertically
+            grid.layout();
+        });
+    });
+</script>
 {{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,0 @@
-<script async src="https://cdnjs.cloudflare.com/ajax/libs/masonry/4.2.2/masonry.pkgd.min.js"
-        integrity="sha512-JRlcvSZAXT8+5SQQAvklXGJuxXTouyq8oIMaYERZQasB8SBDHZaUbeASsJWpk0UUrf89DP3/aefPPrlMR1h1yQ=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
the grid elements were overlapping vertically if the images had completed loading after the layout had first been triggered.

now, the image loading is monitored and will trigger a refresh of the layout when all images have finished loading.